### PR TITLE
automate abao/raml2html

### DIFF
--- a/.gosh.sh
+++ b/.gosh.sh
@@ -112,3 +112,13 @@ function require_cmd {
     fi
     return 0
 }
+
+# Pull in any GOSH_CONTRIB scripts found.
+function use_gosh_contrib {
+    assert_env GOSH_CONTRIB || return 1
+    for contrib in "$GOSH_CONTRIB"/*.sh; do
+        assert_source "$contrib" || return 1
+    done
+    return 0
+}
+

--- a/docs/package.json
+++ b/docs/package.json
@@ -9,6 +9,6 @@
     "url" : "https://github.com/OpenBEL/openbel-server"
   },
   "dependencies": {
-    "raml2html": "~1.1.0"
+    "raml2html": "1.x"
   }
 }

--- a/env.sh
+++ b/env.sh
@@ -43,4 +43,5 @@ default TEST_URLS_FILE          "$TESTS/urls"
 
 ### THE GO SHELL ###
 default GOSH_SCRIPTS            "$DIR"/tools/scripts
+default GOSH_CONTRIB            "$SCRIPTS"/gosh-contrib
 

--- a/tools/scripts/07-raml2html.sh
+++ b/tools/scripts/07-raml2html.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# The next three lines are for the go shell.
+export SCRIPT_NAME="raml2html"
+export SCRIPT_HELP="Run raml2html over our RAML spec."
+[[ "$GOGO_GOSH_SOURCE" -eq 1 ]] && return 0
+
+# Normal script execution starts here.
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"/../../
+. "$DIR"/env.sh || exit 1
+
+"$SCRIPTS"/raml2html.sh
+

--- a/tools/scripts/08-abao.sh
+++ b/tools/scripts/08-abao.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# The next three lines are for the go shell.
+export SCRIPT_NAME="abao"
+export SCRIPT_HELP="Run the abao RAML testing tool."
+[[ "$GOGO_GOSH_SOURCE" -eq 1 ]] && return 0
+
+# Normal script execution starts here.
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"/../../
+. "$DIR"/env.sh || exit 1
+
+"$SCRIPTS"/abao.sh
+

--- a/tools/scripts/abao.sh
+++ b/tools/scripts/abao.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"/../../
+source "$DIR"/env.sh || exit 1
+use_gosh_contrib || exit 1
+assert_env TESTS || exit 1
+
+# Root of where node_modules will go
+export GOSH_CONTRIB_NODE_NPM_MODPATH="$TESTS"
+export GOSH_CONTRIB_NODE_NPM_PKGJSON="$TESTS"/package.json
+cd "$TESTS" || exit 1
+
+# Create the node environment if needed...
+create_node_env
+# ... and use it.
+export PATH="$GOSH_CONTRIB_NODE_NPM_MODPATH/node_modules/.bin":$PATH
+
+echo -en "Running abao... "
+abao || exit 1
+# did we win?
+

--- a/tools/scripts/go.sh
+++ b/tools/scripts/go.sh
@@ -172,7 +172,7 @@ function script {
     local _SCRIPT="$1"
     if [ $# -gt 1 ]; then
         shift
-        export GOSH_SUBMENU_ARGS="$@"
+        export GOSH_SUBMENU_ARGS="$*"
     fi
     # output a script header
     local SCRIPT=$(basename "$_SCRIPT")
@@ -333,7 +333,7 @@ function process_input() {
             script_help "$CHOICE"
         elif [ "$submenu" -eq 1 ]; then
             # Run the submenu w/ args
-            script "$CHOICE" $ARGS
+            script "$CHOICE" "$ARGS"
         elif [ "$item" -eq 1 ]; then
             # Run the script...
             script "$CHOICE"

--- a/tools/scripts/gosh-contrib/node.sh
+++ b/tools/scripts/gosh-contrib/node.sh
@@ -1,0 +1,109 @@
+# gosh-contrib: node.sh
+# https://github.com/formwork-io/gosh-contrib
+#
+# Copyright (c) 2015 Nick Bargnesi
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation
+# files (the "Software"), to deal in the Software without
+# restriction, including without limitation the rights to use,
+# copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following
+# conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+# This contrib uses the following env vars:
+#
+# GOSH_CONTRIB_NODE_NPM_MODPATH
+#   Path to node_modules directory, e.g., $DIR.
+#
+# GOSH_CONTRIB_NODE_NPM_PKGJSON
+#   Path to package.json, e.g., $DIR/package.json.
+#
+
+# Installs dependencies into the node_modules of the current directory.
+# E.g.,
+#    install_node_deps
+# Runs npm install in the current directory.
+function install_node_deps {
+    require_cmd "npm" || return 1
+    echo -en "Running npm install... "
+    # redirect stdout/stderr to mimic silent behavior
+    # (npm currently lacks this functionality as of 2014-10-20)
+    NODE_OUTPUT=$(mktemp) || return 1
+    npm install >"$NODE_OUTPUT" 2>&1
+    EC=$?
+    if [ $EC -ne 0 ]; then
+        echo "failed"
+        cat "$NODE_OUTPUT" || return 1
+        rm "$NODE_OUTPUT" || return 1
+        return 1
+    fi
+    rm "$NODE_OUTPUT" || return 1
+    echo "okay"
+    return 0
+}
+
+# Determines whether the node_modules need updating.
+# E.g.,
+#    if $(node_env_needs_update); then
+#        # update it
+#    fi
+function node_env_needs_update {
+    # returning 0 indicates an update is needed
+    assert_env GOSH_CONTRIB_NODE_NPM_MODPATH || return 0
+    assert_env GOSH_CONTRIB_NODE_NPM_PKGJSON || return 0
+
+    # E.g., $DIR -> $DIR/node_modules
+    local nm_dir="$GOSH_CONTRIB_NODE_NPM_MODPATH"/node_modules
+
+    # directory doesn't exist?
+    if [ ! -d "$nm_dir" ]; then return 0; fi
+    # package.json has changed?
+    if [ "$GOSH_CONTRIB_NODE_NPM_PKGJSON" -nt "$nm_dir" ]; then return 0; fi
+    # previous npm install failed?
+    if [ ! -f "$nm_dir"/.ts ]; then return 0; fi
+    return 1
+}
+
+# Marks the node environment GOSH_CONTRIB_NODE_NPM_MODPATH as complete. Call
+# this function once a node envrionment has been configured and all of the
+# necessary dependencies have been installed.
+function complete_node_env {
+    assert_env GOSH_CONTRIB_NODE_NPM_MODPATH || return 1
+    # E.g., $DIR -> $DIR/node_modules
+    local nm_dir="$GOSH_CONTRIB_NODE_NPM_MODPATH"/node_modules
+    date > "$nm_dir"/.ts || return 1
+    return 0
+}
+
+# Creates a node environment using npm.
+# This function needs GOSH_CONTRIB_NODE_NPM_MODPATH and
+# GOSH_CONTRIB_NODE_NPM_PKGJSON set.
+function create_node_env {
+    assert_env GOSH_CONTRIB_NODE_NPM_MODPATH || exit 1
+    assert_env GOSH_CONTRIB_NODE_NPM_PKGJSON || exit 1
+    if node_env_needs_update; then
+        echo "Node environment out-of-date - it will be created."
+        echo "($GOSH_CONTRIB_NODE_NPM_MODPATH)"
+        # E.g., $DIR -> $DIR/node_modules
+        local nm_dir="$GOSH_CONTRIB_NODE_NPM_MODPATH"/node_modules
+        rm -fr "$nm_dir"
+        install_node_deps || exit 1
+        complete_node_env || exit 1
+        echo
+    fi
+}

--- a/tools/scripts/gosh-contrib/python.sh
+++ b/tools/scripts/gosh-contrib/python.sh
@@ -1,0 +1,135 @@
+# gosh-contrib: python.sh
+# https://github.com/formwork-io/gosh-contrib
+#
+# Copyright (c) 2015 Nick Bargnesi
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation
+# files (the "Software"), to deal in the Software without
+# restriction, including without limitation the rights to use,
+# copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following
+# conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+# This contrib uses the following env vars:
+#
+# GOSH_CONTRIB_PYTHON_VENV
+#   Path to virtual environment to, e.g., $DIR/python-env.
+#
+# GOSH_CONTRIB_PYTHON_REQ_DEPS
+#   Path to required Python dependencies, e.g., $DIR/req.deps.
+#
+# GOSH_CONTRIB_PYTHON_OPT_DEPS
+#   Path to optional Python dependencies, e.g., $DIR/opt.deps.
+#
+# GOSH_CONTRIB_PYTHON_VIRTUALENV
+#   Path to virtualenvironment Python script.
+#
+
+# Installs dependencies into the current virtual environment.
+# E.g.,
+#    install_python_deps $DIR
+# Installs all dependencies listed in GOSH_CONTRIB_PYTHON_REQ_DEP and fails if
+# something failed to install. Tries installing GOSH_CONTRIB_PYTHON_OPT_DEPS but
+# does not fail if something failed to install.
+function install_python_deps {
+    assert_env GOSH_CONTRIB_PYTHON_REQ_DEPS || return 1
+    assert_env GOSH_CONTRIB_PYTHON_OPT_DEPS || return 1
+    assert_env GOSH_CONTRIB_PYTHON_VENV || return 1
+    . "$GOSH_CONTRIB_PYTHON_VENV"/bin/activate
+    vdefault GOSH_CONTRIB_PYTHON_PIP_OPTS "--quiet"
+    if [ -r "$GOSH_CONTRIB_PYTHON_REQ_DEPS" ]; then
+        echo -en "Installing required dependencies... "
+        # shellcheck disable=SC2086
+        if ! pip install $GOSH_CONTRIB_PYTHON_PIP_OPTS \
+                 -r "$GOSH_CONTRIB_PYTHON_REQ_DEPS"; then
+            echo "failed"
+            deactivate
+            return 1
+        fi
+        echo "okay"
+    fi
+    if [ -r "$GOSH_CONTRIB_PYTHON_OPT_DEPS" ]; then
+        echo -en "Installing optional dependencies... "
+        # shellcheck disable=SC2086
+        if ! pip install $GOSH_CONTRIB_PYTHON_PIP_OPTS \
+                 -r "$GOSH_CONTRIB_PYTHON_OPT_DEPS"; then
+            echo "Some errors occurred installing optional dependencies."
+        else
+            echo "okay"
+        fi
+    fi
+    deactivate
+    return 0
+}
+
+# Determines whether the virtual environment GOSH_CONTRIB_PYTHON_VENV needs updating.
+# E.g.,
+#    if $(python_env_needs_update); then
+#        # update it
+#    fi
+function python_env_needs_update {
+    # returning 0 indicates an update is needed
+    assert_env GOSH_CONTRIB_PYTHON_VENV || return 0
+    local venv_dir="$GOSH_CONTRIB_PYTHON_VENV"
+
+    # directory doesn't exist?
+    if [ ! -d "$venv_dir" ]; then return 0; fi
+    # required dependencies have changed?
+    if [ "$GOSH_CONTRIB_PYTHON_REQ_DEPS" -nt "$venv_dir" ]; then return 0; fi
+    # optional dependencies have changed?
+    if [ "$GOSH_CONTRIB_PYTHON_OPT_DEPS" -nt "$venv_dir" ]; then return 0; fi
+    # previous creation failed?
+    if [ ! -f "$venv_dir"/.ts ]; then return 0; fi
+    return 1
+}
+
+# Marks the virtual environment GOSH_CONTRIB_PYTHON_VENV as complete. Call this function once a
+# virtual environment has been configured and all of the necessary dependencies
+# have been installed.
+function complete_python_env {
+    assert_env GOSH_CONTRIB_PYTHON_VENV || return 1
+    date > "$GOSH_CONTRIB_PYTHON_VENV"/.ts || return 1
+    return 0
+}
+
+# Creates a virtual environment for the Python interpreter $1.
+# This function needs GOSH_CONTRIB_PYTHON_VENV and
+# GOSH_CONTRIB_PYTHON_VIRTUALENV set. If GOSH_CONTRIB_PYTHON_VIRTUALENV_ARGS
+# is set, it the value will be passed to virtualenv when creating the
+# environment.
+function create_python_env {
+    assert_env GOSH_CONTRIB_PYTHON_VENV || exit 1
+    assert_env GOSH_CONTRIB_PYTHON_VIRTUALENV || exit 1
+    if [ $# -ne 1 ]; then
+        echo "create_python_env: called without \$1" >&2
+        exit 1
+    fi
+    local INTERP="$1"
+    if python_env_needs_update; then
+        echo "Python virtual environment out-of-date - it will be created."
+        echo "($GOSH_CONTRIB_PYTHON_VENV)"
+        rm -fr "$GOSH_CONTRIB_PYTHON_VENV"
+        local PROMPT="\n($GOSH_CONTRIB_PYTHON_VENV)"
+        local ARGS="$GOSH_CONTRIB_PYTHON_VENV --prompt=${PROMPT}"
+        # shellcheck disable=SC2086
+        $INTERP "$GOSH_CONTRIB_PYTHON_VIRTUALENV" $ARGS || exit 1
+        install_python_deps || exit 1
+        complete_python_env || exit 1
+        echo
+    fi
+}

--- a/tools/scripts/gosh-contrib/ruby.sh
+++ b/tools/scripts/gosh-contrib/ruby.sh
@@ -1,0 +1,123 @@
+# gosh-contrib: ruby.sh
+# https://github.com/formwork-io/gosh-contrib
+#
+# Copyright (c) 2015 Nick Bargnesi
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation
+# files (the "Software"), to deal in the Software without
+# restriction, including without limitation the rights to use,
+# copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following
+# conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+# This contrib uses the following env vars:
+#
+# GOSH_CONTRIB_RUBY_GEMFILE
+#   Path to Gemfile, e.g., $DIR/Gemfile.
+#
+# GOSH_CONTRIB_RUBY_GEMPATH
+#   Path to install gems to, e.g., $DIR/gems.
+#
+
+# Installs gems into the GOSH_CONTRIB_RUBY_GEMPATH using the Gemfile in
+# GOSH_CONTRIB_RUBY_GEMFILE.
+# E.g.,
+#    bundle_install_gems
+function bundle_install_gems {
+    assert_env GOSH_CONTRIB_RUBY_GEMFILE || return 1
+    assert_env GOSH_CONTRIB_RUBY_GEMPATH || return 1
+    vdefault BUNDLE_OPTS "--quiet"
+    echo -en "Running bundle install... "
+    # shellcheck disable=SC2086
+    if ! bundle install $BUNDLE_OPTS \
+                --gemfile="$GOSH_CONTRIB_RUBY_GEMFILE" \
+                --path="$GOSH_CONTRIB_RUBY_GEMPATH"; then
+        echo "failed"
+        return 1
+    fi
+    echo "okay"
+    return 0
+}
+
+# Installs bundler into the GOSH_CONTRIB_RUBY_GEMPATH.
+# E.g.,
+#     gem_install_bundler
+function gem_install_bundler {
+    assert_env GOSH_CONTRIB_RUBY_GEMPATH || return 1
+    require_cmd "gem" || return 1
+    echo -en "Running gem install bundler... "
+    # redirect stdout/stderr to make gem really quiet
+    GEM_OUTPUT=$(mktemp) || return 1
+    GEM_HOME="$GOSH_CONTRIB_RUBY_GEMPATH" gem install bundler >"$GEM_OUTPUT" 2>&1
+    EC=$?
+    if [ $EC -ne 0 ]; then
+        echo "failed"
+        cat "$GEM_OUTPUT" || return 1
+        rm "$GEM_OUTPUT" || return 1
+        return 1
+    fi
+    rm "$GEM_OUTPUT" || return 1
+    echo "okay"
+    return 0
+}
+
+# Determines whether the gem path GOSH_CONTRIB_RUBY_GEMPATH needs updating.
+# E.g.,
+#    if $(gem_path_needs_updating); then
+#        # update it
+#    fi
+function gem_path_needs_updating {
+    # returning 0 indicates an update is needed
+    assert_env GOSH_CONTRIB_RUBY_GEMFILE || return 0
+    assert_env GOSH_CONTRIB_RUBY_GEMPATH || return 0
+    # gem path doesn't exist?
+    if [ ! -d "$GOSH_CONTRIB_RUBY_GEMPATH" ]; then return 0; fi
+    # gemfile changed?
+    if [ "$GOSH_CONTRIB_RUBY_GEMFILE" -nt "$GOSH_CONTRIB_RUBY_GEMPATH" ]; then
+        return 0
+    fi
+    # previous gem path creation failed?
+    if [ ! -f "$GOSH_CONTRIB_RUBY_GEMPATH"/.ts ]; then return 0; fi
+    return 1
+}
+
+# Marks the gem path GOSH_CONTRIB_RUBY_GEMPATH as complete. Call this function
+# once a gem path has been configured and all of the necessary dependencies
+# have been installed.
+function complete_gem_path {
+    assert_env GOSH_CONTRIB_RUBY_GEMPATH || return 1
+    date > "$GOSH_CONTRIB_RUBY_GEMPATH"/.ts || return 1
+    return 0
+}
+
+# Creates a gem path.
+# This function needs GOSH_CONTRIB_RUBY_GEMFILE and GOSH_CONTRIB_RUBY_GEMPATH
+# set.
+function create_gem_path {
+    assert_env GOSH_CONTRIB_RUBY_GEMFILE || return 1
+    assert_env GOSH_CONTRIB_RUBY_GEMPATH || return 1
+    if gem_path_needs_updating; then
+        echo "Gem path out-of-date - it will be created."
+        echo "($GOSH_CONTRIB_RUBY_GEMPATH)"
+        rm -fr "$GOSH_CONTRIB_RUBY_GEMPATH"
+        gem_install_bundler || exit 1
+        bundle_install_gems || exit 1
+        complete_gem_path || exit 1
+        echo
+    fi
+}

--- a/tools/scripts/raml2html.sh
+++ b/tools/scripts/raml2html.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"/../../
+source "$DIR"/env.sh || exit 1
+use_gosh_contrib || exit 1
+assert_env DOCS || exit 1
+
+# Root of where node_modules will go
+export GOSH_CONTRIB_NODE_NPM_MODPATH="$DOCS"
+export GOSH_CONTRIB_NODE_NPM_PKGJSON="$DOCS"/package.json
+cd "$DOCS" || exit 1
+
+# Create the node environment if needed...
+create_node_env
+# ... and use it.
+export PATH="$GOSH_CONTRIB_NODE_NPM_MODPATH/node_modules/.bin":$PATH
+
+echo -en "Generating RAML page... "
+OUT=$(mktemp)
+# raml2html treats stdout as stderr if failures occur, hence the temp file
+raml2html "$DOCS"/openbel-api.raml > "$OUT"
+EC=$?
+if [ $EC -ne 0 ]; then
+    echo FAIL
+    cat $OUT || exit 1
+    rm $OUT || exit 1
+    exit $EC
+else
+    mv "$OUT" "$DOCS"/openbel-api.html || exit 1
+    echo done
+fi
+exit 0
+


### PR DESCRIPTION
- [x] bump openbel-server to formwork-io/gosh [v0.4](https://github.com/formwork-io/gosh/releases/tag/v0.4)
  - This enables support for [formwork-io/gosh-contrib](https://github.com/formwork-io/gosh-contrib)
- [x] bump raml2html to latest 1.x release
- [x] enable gosh-contrib in ```$SCRIPTS/gosh-contrib```
- [x] add abao.sh for ``$TESTS``/package.json automation
- [x] add raml2html.sh for ``$TESTS``/package.json automation
- [ ] write ``openbel-api.html`` to?

Not sure where the HTML artifact should get dumped during generation. It's being dumped to [``$DOCS`` right now](https://github.com/nbargnesi/openbel-server/blob/gosh/tools/scripts/raml2html.sh#L28).